### PR TITLE
記事一覧ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,8 @@ gem "turbo-rails"
 gem "stimulus-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
+# ダミーデータ作成用
+gem 'faker'
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
+    faker (3.5.1)
+      i18n (>= 1.8.11, < 2)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -371,6 +373,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails (~> 1.4)
   debug
+  faker
   importmap-rails
   jbuilder
   kamal

--- a/app/assets/stylesheets/card.scss
+++ b/app/assets/stylesheets/card.scss
@@ -9,6 +9,11 @@ $avatar-size: 32px;
   cursor: pointer;
   box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.25);
 
+  &_title {
+    font-size: 22px;
+    margin-bottom: 8px;
+  }
+
   &_heart {
     display: flex;
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,5 +1,5 @@
 class ArticlesController < ApplicationController
   def index
-    @article = Article.first
+    @articles = Article.all
   end
 end

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -8,11 +8,15 @@
     </div>
   </div>
 
+  <% @articles.each do |article| %>
   <div class="card">
     <div class="card_image">
       <%= image_tag 'eyecatch1.png' %>
     </div>
     <div class="card_content">
+      <div class="card_title">
+        <%= article.title %>
+      </div>
       <div class="card_heart">
         <%= image_tag 'heart.svg' %>
         <span>23</span>
@@ -26,42 +30,6 @@
       </div>
     </div>
   </div>
+  <% end %>
 
-  <div class="card">
-    <div class="card_image">
-      <%= image_tag 'eyecatch2.png' %>
-    </div>
-    <div class="card_content">
-      <div class="card_heart">
-        <%= image_tag 'heart.svg' %>
-        <span>23</span>
-      </div>
-      <div class="card_detail">
-        <%= image_tag 'default-avatar.png' %>
-        <div>
-          <p>cohki0305</p>
-          <p>2020/4/16</p>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="card">
-    <div class="card_image">
-      <%= image_tag 'eyecatch2.png' %>
-    </div>
-    <div class="card_content">
-      <div class="card_heart">
-        <%= image_tag 'heart.svg' %>
-        <span>23</span>
-      </div>
-      <div class="card_detail">
-        <%= image_tag 'default-avatar.png' %>
-        <div>
-          <p>cohki0305</p>
-          <p>2020/4/16</p>
-        </div>
-      </div>
-    </div>
-  </div>
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,10 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+10.times do
+  Article.create(
+    title:   Faker::Lorem.sentence(word_count: 5),
+    content: Faker::Lorem.sentence(word_count: 100)
+  )
+end


### PR DESCRIPTION
## 概要
- 記事一覧ページの実装

## 対応内容
- Articleテーブルから全てのデータを取得し、`articles/index.html.erb`で一覧表示するように実装。
- `card.scss`に記事のタイトルのプロパティを追加。
- FakerをGemfileに追加。

## 動作確認方法
### エラーメッセージ
1. コマンド`bin/dev`で起動後`localhost:3000`にアクセス。
2. 記事の一覧が表示されている。

## 画面のスクリーンショット
![localhost_3000_(iPhone XR)](https://github.com/user-attachments/assets/4ccaf2c7-6e41-4941-9f5c-e44a8b571e75)

## 備考
画像や投稿ユーザは今後実装予定。
