### PR TITLE
記事の登録機能の修正

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -3,6 +3,9 @@
 @use 'variables' as *;
 @use 'card' as *;
 @use 'article' as *;
+@use 'buttons' as *;
+@use 'form' as *;
+@use 'flash' as *;
 
 html {
   word-spacing: 1px;
@@ -36,4 +39,21 @@ a {
 .container {
   padding: 16px 16px;
   width: 100%;
+}
+
+.float_btn {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  width: 64px;
+  height: 64px;
+  border-radius: 100%;
+  text-align: center;
+  background-color: $primary-color;
+  color: white;
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.25);
+
+  i {
+    margin-top: 22px;
+  }
 }

--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -1,0 +1,11 @@
+@use 'variables' as *;
+
+.btn-primary {
+  background-color: $primary-color;
+  border: none;
+  width: 100%;
+  text-align: center;
+  color: white;
+  padding: 16px 0;
+  font-weight: bold;
+}

--- a/app/assets/stylesheets/flash.scss
+++ b/app/assets/stylesheets/flash.scss
@@ -1,0 +1,49 @@
+.flash {
+  position: fixed;
+  top: 16px;
+  font-size: 12px;
+  right: 16px;
+  width: 160px;
+  background: white;
+  -webkit-animation: fade-in-out;
+  animation: fade-in-out;
+  visibility: hidden;
+  z-index: 1;
+  padding: 16px;
+  animation-duration: 5s;
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.25);
+}
+
+@-webkit-keyframes fade-in-out {
+  0% {
+    visibility: visible;
+    opacity: 1;
+  }
+
+  50% {
+    visibility: visible;
+    opacity: 1;
+  }
+
+  100% {
+    visibility: hidden;
+    opacity: 0;
+  }
+}
+
+@keyframes fade-in-out {
+  0% {
+    visibility: visible;
+    opacity: 1;
+  }
+
+  50% {
+    visibility: visible;
+    opacity: 1;
+  }
+
+  100% {
+    visibility: hidden;
+    opacity: 0;
+  }
+}

--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -1,0 +1,21 @@
+input {
+  &.text {
+    width: 100%;
+    margin: 8px 0px;
+    padding: 16px 24px;
+    border: 1px solid #ebebeb;
+  }
+}
+
+label {
+  font-size: 12px;
+}
+
+textarea {
+  width: 100%;
+  margin: 8px 0px;
+  padding: 8px 8px;
+  min-height: 440px;
+  resize: vertical;
+  border: 1px solid #ebebeb;
+}

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -6,4 +6,23 @@ class ArticlesController < ApplicationController
   def show
     @article = Article.find(params[:id])
   end
+
+  def new
+    @article = Article.new
+  end
+
+  def create
+    @article = Article.new(article_params)
+    if @article.save
+      redirect_to article_path(@article), notice: '保存できたよ'
+    else
+      flash.now[:error] = '保存に失敗しました'
+      render :new
+    end
+  end
+
+  private
+  def article_params
+    params.require(:article).permit(:title, :content)
+  end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,2 +1,4 @@
 class Article < ApplicationRecord
+  validates :title, presence: true
+  validates :content, presence: true
 end

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -33,5 +33,9 @@
       </div>
     <% end %>
   <% end %>
-
+  <%= link_to new_article_path do %>
+    <div class="float_btn">
+      <i class="fa fa-plus"></i>
+    </div>
+  <% end %>
 </div>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,0 +1,22 @@
+<div class="container">
+  <ul>
+    <% @article.errors.full_messages.each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+  </ul>
+  <%= form_with(model: @article, url: articles_path, method: 'post', local: true, data: { turbo: false}) do |f| %>
+  <div class="">
+    <%= f.label :title, 'タイトル' %>
+  </div>
+  <div class="">
+    <%= f.text_field :title %>
+  </div>
+  <div class="">
+    <%= f.label :content, 'コンテンツ' %>
+  </div>
+  <div class="">
+    <%= f.text_area :content %>
+  </div>
+  <%= f.submit '保存', class: 'btn-primary' %>
+  <% end %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
+    <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
@@ -33,6 +34,15 @@
         </div>
       </div>
     </header>
+    <% if flash.present? %>
+      <div class="flash">
+        <% flash.each do |key, value|%>
+          <div class="<%= key %>">
+            <%= value %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
     <%= yield %>
   </body>
 </html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,6 @@ module BlogApp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,210 @@
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        restrict_dependent_destroy:
+          has_one: '%{record}が存在しているので削除できません'
+          has_many: '%{record}が存在しているので削除できません'
+    attributes:
+      article:
+        title: 'タイトル'
+        content: '内容'
+  date:
+    abbr_day_names:
+      - 日
+      - 月
+      - 火
+      - 水
+      - 木
+      - 金
+      - 土
+    abbr_month_names:
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
+    day_names:
+      - 日曜日
+      - 月曜日
+      - 火曜日
+      - 水曜日
+      - 木曜日
+      - 金曜日
+      - 土曜日
+    formats:
+      default: '%Y/%m/%d'
+      long: '%Y年%m月%d日(%a)'
+      short: '%m/%d'
+    month_names:
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
+    order:
+      - :year
+      - :month
+      - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: '%{count}年弱'
+      half_a_minute: 30秒前後
+      less_than_x_seconds:
+        one: 1秒以内
+        other: '%{count}秒未満'
+      less_than_x_minutes:
+        one: 1分以内
+        other: '%{count}分未満'
+      over_x_years:
+        one: 1年以上
+        other: '%{count}年以上'
+      x_seconds:
+        one: 1秒
+        other: '%{count}秒'
+      x_minutes:
+        one: 1分
+        other: '%{count}分'
+      x_days:
+        one: 1日
+        other: '%{count}日'
+      x_months:
+        one: 1ヶ月
+        other: '%{count}ヶ月'
+      x_years:
+        one: 1年
+        other: '%{count}年'
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: '%{attribute}%{message}'
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: '%{model}にエラーが発生しました'
+        other: '%{model}に%{count}個のエラーが発生しました'
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ','
+        format: '%n%u'
+        precision: 0
+        separator: '.'
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ','
+      precision: 3
+      separator: '.'
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: '%n %u'
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: '%n%u'
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: '%n%'
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: '、'
+      two_words_connector: '、'
+      words_connector: '、'
+  time:
+    am: 午前
+    formats:
+      default: '%Y年%m月%d日(%a) %H時%M分%S秒 %z'
+      long: '%Y/%m/%d %H:%M'
+      short: '%m/%d %H:%M'
+    pm: 午後

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   root to: 'articles#index'
 
-  resources :articles, only: [:show]
+  resources :articles, only: [:show, :new, :create]
 end


### PR DESCRIPTION
# PRテンプレート
## 概要
- 記事の新規登録画面の実装
- 記事の新規登録処理の実装

## 対応内容
- `localhost:3000/articles/new`にアクセス時、記事の新規登録画面に遷移するように実装。
- 新規登録画面の保存ボタン押下時に入力された値をデータベースに登録する処理の実装。
- Articleモデルのカラムに空白を許可しないバリデーションを追加。
- ja.ymlを作成し、エラーメッセージを日本語で表示されるように実装。

## 動作確認方法
### ユーザー更新
1. コマンド`bin/dev`で起動後`localhost:3000/articles/new`にアクセス。
2. タイトルとコンテンツに値を入力。
3. 保存ボタンを押下後、入力された値でデータベースに登録され、作成された記事詳細画面にリダイレクトされる。
### エラーメッセージ
1. コマンド`bin/dev`で起動後`localhost:3000/articles/new`にアクセス。
2. 何も入力せず、保存ボタンを押下する。
3. エラーメッセージとフラッシュメッセージが画面に出力される。

## 画面のスクリーンショット
![スクリーンショット 2025-06-15 14 42 16](https://github.com/user-attachments/assets/72021e4f-ef8a-45fc-9514-9303d41d53dd)