### PR TITLE
記事削除機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+  gem "htmlbeautifier"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,7 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    htmlbeautifier (1.4.3)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.1.0)
@@ -374,6 +375,7 @@ DEPENDENCIES
   cssbundling-rails (~> 1.4)
   debug
   faker
+  htmlbeautifier
   importmap-rails
   jbuilder
   kamal

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -35,6 +35,12 @@ class ArticlesController < ApplicationController
     end
   end
 
+  def destroy
+    article = Article.find(params[:id])
+    article.destroy!
+    redirect_to root_path, notice: '削除に成功しました'
+  end
+
   private
   def article_params
     params.require(:article).permit(:title, :content)

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -5,18 +5,18 @@
     <% end %>
   </ul>
   <%= form_with(model: @article, url: article_path(@article), method: 'put', local: true, data: { turbo: false}) do |f| %>
-  <div class="">
-    <%= f.label :title, 'タイトル' %>
-  </div>
-  <div class="">
-    <%= f.text_field :title %>
-  </div>
-  <div class="">
-    <%= f.label :content, 'コンテンツ' %>
-  </div>
-  <div class="">
-    <%= f.text_area :content %>
-  </div>
-  <%= f.submit '保存', class: 'btn-primary' %>
+    <div class="">
+      <%= f.label :title, 'タイトル' %>
+    </div>
+    <div class="">
+      <%= f.text_field :title %>
+    </div>
+    <div class="">
+      <%= f.label :content, 'コンテンツ' %>
+    </div>
+    <div class="">
+      <%= f.text_area :content %>
+    </div>
+    <%= f.submit '保存', class: 'btn-primary' %>
   <% end %>
 </div>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -7,7 +7,6 @@
       タイムライン
     </div>
   </div>
-
   <% @articles.each do |article| %>
     <%= link_to article_path(article) do %>
       <div class="card">

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -11,6 +11,7 @@
         <%= image_tag 'actions.svg', class: 'dropbtn' %>
         <div class="dropdown-content mini">
           <%= link_to '編集する', edit_article_path(@article) %>
+          <%= link_to "削除する", article_path(@article), data: {turbo_method: 'delete', turbo_confirm: '本当に削除してもよろしいですか？'} %>
         </div>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   root to: 'articles#index'
 
-  resources :articles, only: [:show, :new, :create, :edit, :update]
+  resources :articles, only: [:show, :new, :create, :edit, :update, :destroy]
 end


### PR DESCRIPTION
# PRテンプレート
## 概要
- 記事削除画面の実装

## 対応内容
- articles_controller.rbにdestroyメソッドを追加。
- `articles/show.html.erb`に記事を削除するリンクを追加。

## 動作確認方法
1. コマンド`bin/dev`で起動後``localhost:3000/articles/:id/edit`にアクセス。
2. 「・・・」マークを押下し、削除するリンクを押下する。
3. 該当記事が削除され、ルートパス（記事一覧ページ）にリダイレクトする。

## 画面のスクリーンショット
![スクリーンショット 2025-06-17 21 24 37](https://github.com/user-attachments/assets/7e12bec5-e6f8-47ab-94b5-f83149710ba2)
