### PR TITLE
articleモデルにバリデーションの追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ require:
   - rubocop-rails
 
 AllCops:
+  TargetRubyVersion: 3.4.1
   SuggestExtensions: false
   # 最新のルールを適用する
   NewCops: enable

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -11,9 +11,22 @@
 
 class Article < ApplicationRecord
   validates :title, presence: true
+  validates :title, length: { minimum: 2, maximum: 100 }
+  validates :title, format: { with: /\A(?!@)/ }
   validates :content, presence: true
+  validates :content, length: { minimum: 10 }
+  validates :content, uniqueness: true
+
+  validate :validate_title_and_content_length
 
   def display_created_at
     I18n.l(created_at, format: :default)
+  end
+
+  private
+
+  def validate_title_and_content_length
+    char_count = title.length + content.length
+    errors.add(:content, '100文字以上で') unless char_count > 100
   end
 end


### PR DESCRIPTION
# PRテンプレート
## 概要
- articleモデルにバリデーションの追加

## 対応内容
- article.rbのtitileカラムに文字列の最大最小数のバリデーションの追加。
- article.rbのtitileカラムに不正な文字列を許可しないバリデーションの追加。
- article.rbのcontentカラムに文字列の最小数のバリデーションの追加。
- article.rbのcontentカラムに一意制約のバリデーションの追加。

## 動作確認方法
### 記事登録or更新
#### エラーメッセージ
1. コマンド`bin/dev`で起動後`localhost:3000/articles/new`にアクセス。
2. 不正な文字数or不正な文字を入力し登録か更新を試みる。
3. エラーメッセージが画面に出力される。

## 画面のスクリーンショット
![スクリーンショット 2025-06-20 23 01 01](https://github.com/user-attachments/assets/43f79d4b-6e5e-4beb-9bd8-857d5954314f)