### PR TITLE
記事にコメントの追加機能の実装

### DIFF
--- a/app/assets/stylesheets/article.scss
+++ b/app/assets/stylesheets/article.scss
@@ -8,8 +8,16 @@ $avatar-size: 32px;
   box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.25);
   position: relative;
 
+  h2 {
+    font-size: 16px;
+  }
+
   &_title {
     font-size: 22px;
+  }
+
+  &_comment {
+    padding: 12px 0;
   }
 
   &_detail {

--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -9,3 +9,13 @@
   padding: 16px 0;
   font-weight: bold;
 }
+
+.btn-secondary {
+  background-color: white;
+  border: solid 1px $primary-color;
+  width: 100%;
+  text-align: center;
+  color: $primary-color;
+  padding: 16px 0;
+  font-weight: bold;
+}

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -8,7 +8,9 @@ class ArticlesController < ApplicationController
     @articles = Article.all
   end
 
-  def show; end
+  def show
+    @comments = @article.comments
+  end
 
   def new
     @article = current_user.articles.build

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -5,4 +5,21 @@ class CommentsController < ApplicationController
     article = Article.find(params[:article_id])
     @comment = article.comments.build
   end
+
+  def create
+    article = Article.find(params[:article_id])
+    @comment = article.comments.build(comment_params)
+    if @comment.save
+      redirect_to article_path(article), notice: 'コメントを追加しました'
+    else
+      flash.now[:error] = '保存に失敗しました'
+      render :new
+    end
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:content)
+  end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class CommentsController < ApplicationController
+  def new
+    article = Article.find(params[:article_id])
+    @comment = article.comments.build
+  end
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -26,6 +26,7 @@ class Article < ApplicationRecord
 
   validate :validate_title_and_content_length
 
+  has_many :comments, dependent: :destroy
   belongs_to :user
 
   def display_created_at

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id         :integer          not null, primary key
+#  article_id :integer          not null
+#  content    :text             not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_comments_on_article_id  (article_id)
+#
+
+class Comment < ApplicationRecord
+  belongs_to :article
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -15,4 +15,5 @@
 
 class Comment < ApplicationRecord
   belongs_to :article
+  validates :content, presence: true
 end

--- a/app/views/articles/show.html.haml
+++ b/app/views/articles/show.html.haml
@@ -16,3 +16,8 @@
     = @article.content
   .article_heart
     = image_tag 'heart.svg'
+
+.container 
+  = link_to new_article_comment_path(@article) do
+    .btn-secondary
+      コメントを追加

--- a/app/views/articles/show.html.haml
+++ b/app/views/articles/show.html.haml
@@ -17,6 +17,12 @@
   .article_heart
     = image_tag 'heart.svg'
 
+.article 
+  %h2 コメント一覧
+  - @comments.each do |c|
+    .article_comment
+      %p= c.content 
+
 .container 
   = link_to new_article_comment_path(@article) do
     .btn-secondary

--- a/app/views/comments/new.html.haml
+++ b/app/views/comments/new.html.haml
@@ -1,0 +1,11 @@
+.container
+  %ul
+    - @comment.errors.full_messages.each do |message|
+      %li= message
+
+  = form_with(model: @comment, url: article_comments_path(@comment.article), local: true) do |f|
+    %div
+      = f.label :content, '内容'
+    %div
+      = f.text_area :content
+    =f.submit '保存', class: 'btn-primary'

--- a/app/views/comments/new.html.haml
+++ b/app/views/comments/new.html.haml
@@ -3,7 +3,7 @@
     - @comment.errors.full_messages.each do |message|
       %li= message
 
-  = form_with(model: @comment, url: article_comments_path(@comment.article), local: true) do |f|
+  = form_with(model: @comment, url: article_comments_path(@comment.article), local: true, data: { turbo: false }) do |f|
     %div
       = f.label :content, '内容'
     %div

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,7 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'articles#index'
 
-  resources :articles
+  resources :articles do
+    resources :comments, only: [:new, :create]
+  end
 end

--- a/db/migrate/20250622114344_create_comments.rb
+++ b/db/migrate/20250622114344_create_comments.rb
@@ -1,0 +1,9 @@
+class CreateComments < ActiveRecord::Migration[8.0]
+  def change
+    create_table :comments do |t|
+      t.references :article, null: false
+      t.text :content, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_09_082857) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_22_114344) do
   create_table "articles", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "title", null: false
@@ -18,6 +18,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_09_082857) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_articles_on_user_id"
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.integer "article_id", null: false
+    t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["article_id"], name: "index_comments_on_article_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id         :integer          not null, primary key
+#  article_id :integer          not null
+#  content    :text             not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_comments_on_article_id  (article_id)
+#
+
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id         :integer          not null, primary key
+#  article_id :integer          not null
+#  content    :text             not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_comments_on_article_id  (article_id)
+#
+
+require "test_helper"
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
- 記事にコメントの追加機能の実装

## 対応内容
- コメント登録ページの作成。
- 記事詳細ページにコメント登録ページのリンクを追加。
- コメント登録処理の実装。（validates含む）
- 記事詳細ページにコメント一覧を表示。

## 動作確認方法
### 記事詳細ページ
1. コマンド`bin/dev`で起動後、作成済みユーザーでログインを行い`localhost:3000/articles/:id`にアクセス。
2. コメント追加ボタンを押下。
3. コメント登録ページに遷移する。
### コメント登録ページ
1. コマンド`bin/dev`で起動後、作成済みユーザーでログインを行い`localhost:3000/articles/:article_id/comments/new`にアクセス。
2. 内容をテキストエリアに入力し、保存ボタンを押下する。
3. 保存に成功すると、記事詳細ページにリダイレクトする。

## 画面のスクリーンショット
| 記事詳細ページ | コメント登録ページ | コメント登録ページ（エラー） |
|----|----|----|
| ![スクリーンショット 2025-06-22 22 04 58](https://github.com/user-attachments/assets/7982d9ec-e5cc-4f35-a77d-4befc3f237ff) | ![スクリーンショット 2025-06-22 22 07 22](https://github.com/user-attachments/assets/ddddabcc-b141-442d-a6f0-13f9f80143b2)| ![スクリーンショット 2025-06-22 22 08 29](https://github.com/user-attachments/assets/543b0d84-65d9-4ced-9233-36e769345591) |
