### PR TITLE
フォロー機能の実装

### DIFF
--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -15,7 +15,7 @@ $back-icon-size: 16px;
     color: white;
   }
 
-  &_loginBtn {
+  a.header_loginBtn {
     background-color: $base-bg-color;
     height: $avatar-size;
     border-radius: 8px;

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,0 +1,6 @@
+class AccountsController < ApplicationController
+  def show
+    @user = User.find(params[:id])
+    redirect_to profile_path if @user == current_user
+  end
+end

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -1,0 +1,8 @@
+class FollowsController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    current_user.follow!(params[:account_id])
+    redirect_to account_path(params[:account_id])
+  end
+end

--- a/app/controllers/unfollows_controller.rb
+++ b/app/controllers/unfollows_controller.rb
@@ -1,0 +1,8 @@
+class UnfollowsController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    current_user.unfollow!(params[:account_id])
+    redirect_to account_path(params[:account_id])
+  end
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -15,4 +15,6 @@
 #
 
 class Relationship < ApplicationRecord
+  belongs_to :follower, class_name: 'User'
+  belongs_to :following, class_name: 'User'
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: relationships
+#
+#  id           :integer          not null, primary key
+#  following_id :integer          not null
+#  follower_id  :integer          not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_relationships_on_follower_id   (follower_id)
+#  index_relationships_on_following_id  (following_id)
+#
+
+class Relationship < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,13 +31,22 @@ class User < ApplicationRecord
   end
 
   def follow!(user)
-    following_relationships.create!(following_id: user.id)
+    user_id = if user.is_a?(User)
+                user.id
+              else
+                user
+              end
+    following_relationships.create!(following_id: user_id)
   end
 
   def unfollow!(user)
     # follower_relationships.destroy!(follower_id: user.id)
     relation = following_relationships.find_by!(following_id: user.id)
     relation.destroy!
+  end
+
+  def has_followed?(user)
+    following_relationships.exists?(following_id: user.id)
   end
 
   def prepare_profile

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,13 @@ class User < ApplicationRecord
   has_many :articles, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :favorite_articles, through: :likes, source: :article
+
+  has_many :following_relationships, foreign_key: 'follower_id', class_name: 'Relationship', dependent: :destroy
+  has_many :followings, through: :following_relationships, source: :following
+
+  has_many :follower_relationships, foreign_key: 'following_id', class_name: 'Relationship', dependent: :destroy
+  has_many :followers, through: :follower_relationships, source: :follower
+
   has_one :profile, dependent: :destroy
 
   delegate :birthday, :age, :gender, to: :profile, allow_nil: true
@@ -21,6 +28,16 @@ class User < ApplicationRecord
 
   def display_name
     profile&.nickname || email.split('@').first
+  end
+
+  def follow!(user)
+    following_relationships.create!(following_id: user.id)
+  end
+
+  def unfollow!(user)
+    # follower_relationships.destroy!(follower_id: user.id)
+    relation = following_relationships.find_by!(following_id: user.id)
+    relation.destroy!
   end
 
   def prepare_profile

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,17 +31,13 @@ class User < ApplicationRecord
   end
 
   def follow!(user)
-    user_id = if user.is_a?(User)
-                user.id
-              else
-                user
-              end
+    user_id = get_user_id(user)
     following_relationships.create!(following_id: user_id)
   end
 
   def unfollow!(user)
-    # follower_relationships.destroy!(follower_id: user.id)
-    relation = following_relationships.find_by!(following_id: user.id)
+    user_id = get_user_id(user)
+    relation = following_relationships.find_by!(following_id: user_id)
     relation.destroy!
   end
 
@@ -59,5 +55,11 @@ class User < ApplicationRecord
     else
       'default-avatar.png'
     end
+  end
+
+  private
+
+  def get_user_id(user)
+    user.is_a?(User) ? user.id : user
   end
 end

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -1,0 +1,1 @@
+= render 'commons/profile', user: @user

--- a/app/views/articles/show.html.haml
+++ b/app/views/articles/show.html.haml
@@ -4,7 +4,8 @@
       = image_tag @article.eyecatch
   %h1.article_title= @article.title
   .article_detail
-    = image_tag @article.user.avatar_image
+    = link_to account_path(@article.user) do
+      = image_tag @article.user.avatar_image
     %div
       %p= @article.author_name
       %p= @article.display_created_at

--- a/app/views/commons/_profile.html.haml
+++ b/app/views/commons/_profile.html.haml
@@ -1,0 +1,20 @@
+-# ログインしているユーザーのプロフィール
+.container.profilePage
+  .profilePage_user
+    .profilePage_user_image
+      = image_tag user.avatar_image
+    .profilePage_user_basicInfo
+      .profilePage_user_name
+        .profilePage_user_displayName
+          #{user.display_name} (#{user.age || '?歳'} ・ #{I18n.t("enum.genders.#{user.gender || 'unknown'}")})
+        .profilePage_user_actionButton
+          - if user == current_user
+            = link_to 'Edit', edit_profile_path
+          - else 
+            = link_to 'Follow', '#'
+      .profilePage_user_introduction
+        = user.profile&.introduction
+
+  -# ログインしているユーザーの記事一覧
+  - user.articles.each do |article|
+    = render 'commons/article', article: article

--- a/app/views/commons/_profile.html.haml
+++ b/app/views/commons/_profile.html.haml
@@ -12,9 +12,9 @@
             = link_to 'Edit', edit_profile_path
           - else 
             - if current_user&.has_followed?(user)
-              %p フォロー済み
+              = link_to 'フォロー解除', account_unfollows_path(user), data: {turbo_method: 'post'}
             - else 
-              = link_to 'Follow', account_follows_path(user), data: {turbo_method: 'post'}
+              = link_to 'フォロー', account_follows_path(user), data: {turbo_method: 'post'}
       .profilePage_user_introduction
         = user.profile&.introduction
 

--- a/app/views/commons/_profile.html.haml
+++ b/app/views/commons/_profile.html.haml
@@ -11,7 +11,10 @@
           - if user == current_user
             = link_to 'Edit', edit_profile_path
           - else 
-            = link_to 'Follow', '#'
+            - if current_user&.has_followed?(user)
+              %p フォロー済み
+            - else 
+              = link_to 'Follow', account_follows_path(user), data: {turbo_method: 'post'}
       .profilePage_user_introduction
         = user.profile&.introduction
 

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -1,17 +1,1 @@
--# ログインしているユーザーのプロフィール
-.container.profilePage
-  .profilePage_user
-    .profilePage_user_image
-      = image_tag current_user.avatar_image
-    .profilePage_user_basicInfo
-      .profilePage_user_name
-        .profilePage_user_displayName
-          #{current_user.display_name} (#{current_user.age} ・ #{I18n.t("enum.genders.#{current_user.gender}")})
-        .profilePage_user_actionButton
-          = link_to 'Edit', edit_profile_path
-      .profilePage_user_introduction
-        = current_user.profile&.introduction
-
-  -# ログインしているユーザーの記事一覧
-  - current_user.articles.each do |article|
-    = render 'commons/article', article: article
+= render 'commons/profile', user: current_user

--- a/config/locales/enum.ja.yml
+++ b/config/locales/enum.ja.yml
@@ -4,3 +4,4 @@ ja:
       male: '男性'
       female: '女性'
       other: 'その他'
+      unknown: '性別未入力'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
     resource :like, only: [:create, :destroy]
   end
 
+  resources :accounts, only: [:show]
+
   resource :profile, only: [:show, :edit, :update]
   resources :favorites, only: [:index]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
 
   resources :accounts, only: [:show] do
     resources :follows, only: [:create]
+    resources :unfollows, only: [:create]
   end
 
   resource :profile, only: [:show, :edit, :update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,9 @@ Rails.application.routes.draw do
     resource :like, only: [:create, :destroy]
   end
 
-  resources :accounts, only: [:show]
+  resources :accounts, only: [:show] do
+    resources :follows, only: [:create]
+  end
 
   resource :profile, only: [:show, :edit, :update]
   resources :favorites, only: [:index]

--- a/db/migrate/20250625121226_create_relationships.rb
+++ b/db/migrate/20250625121226_create_relationships.rb
@@ -1,0 +1,10 @@
+class CreateRelationships < ActiveRecord::Migration[8.0]
+  def change
+    create_table :relationships do |t|
+      t.references :following, null: false, foreign_key: { to_table: :users }
+      t.references :follower,  null: false, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_25_070939) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_25_121226) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -86,6 +86,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_25_070939) do
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
+  create_table "relationships", force: :cascade do |t|
+    t.integer "following_id", null: false
+    t.integer "follower_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["follower_id"], name: "index_relationships_on_follower_id"
+    t.index ["following_id"], name: "index_relationships_on_following_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -100,4 +109,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_25_070939) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "relationships", "users", column: "follower_id"
+  add_foreign_key "relationships", "users", column: "following_id"
 end

--- a/test/fixtures/relationships.yml
+++ b/test/fixtures/relationships.yml
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: relationships
+#
+#  id           :integer          not null, primary key
+#  following_id :integer          not null
+#  follower_id  :integer          not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_relationships_on_follower_id   (follower_id)
+#  index_relationships_on_following_id  (following_id)
+#
+
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: relationships
+#
+#  id           :integer          not null, primary key
+#  following_id :integer          not null
+#  follower_id  :integer          not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_relationships_on_follower_id   (follower_id)
+#  index_relationships_on_following_id  (following_id)
+#
+
+require "test_helper"
+
+class RelationshipTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
- フォロー機能の実装

## 対応内容
- Relationshipsテーブルの作成。
- `user.rb`にフォロー、アンフォローメソッドを実装。
- 記事詳細ページのユーザーアイコンからユーザー詳細ページに遷移されるように修正。
- ユーザー詳細ページにフォローボタンを追加。
- 記事詳細ページのフォローボタンを押下時に、該当ユーザーをフォローできるように実装。
- 記事詳細ページで該当記事のユーザーをフォロー時にフォロー解除ボタンを押下後、該当ユーザーをアンフォローできるように実装。
- ヘッダーのログインボタンのレイアウト修正。

## 動作確認方法
フォロー機能
1. コマンド`bin/dev`で起動後、作成済みユーザーでログインを行い`localhost:3000/articles/show`にアクセス（自分が作成していない記事）。
2. ユーザーアイコンを押下し、該当ユーザーのプロフィールページに遷移。
3. フォローボタンを押下すると、ボタンの表記が`フォロー解除`に切り替わり、該当ユーザーをフォローすることができる。
#### アンフォロー機能
1. 上記`フォロー機能`の1、2と同様の操作を行う。
2. フォロー解除ボタンを押下すると、ボタンの表記が`フォロー`に切り替わり、該当ユーザーをアンフォローすることが出来る。

## 画面のスクリーンショット
| 記事詳細ページ（フォロー前） | 記事詳細ページ（フォロー後） |
| --- | --- |
|![article-show-before](https://github.com/user-attachments/assets/aa5753c5-b524-477e-8e7b-06e490aef419)|![article-show-afoter](https://github.com/user-attachments/assets/f6bf217e-7c40-47e5-9da1-c142e803cc3c)|