### PR TITLE
メール送付機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,8 @@ group :development do
   gem "web-console"
   gem "htmlbeautifier"
   gem 'erb2haml'
+  gem 'letter_opener'
+  gem 'letter_opener_web', '~> 1.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
       xpath (~> 3.2)
     case_transform (0.2)
       activesupport
+    childprocess (5.1.0)
+      logger (~> 1.5)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
@@ -200,6 +202,16 @@ GEM
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
     language_server-protocol (3.17.0.5)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (1.4.1)
+      actionmailer (>= 3.2)
+      letter_opener (~> 1.0)
+      railties (>= 3.2)
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.24.1)
@@ -469,6 +481,8 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
+  letter_opener
+  letter_opener_web (~> 1.0)
   propshaft
   pry-byebug
   puma (>= 5.0)

--- a/app/mailers/relationship_mailer.rb
+++ b/app/mailers/relationship_mailer.rb
@@ -1,0 +1,7 @@
+class RelationshipMailer < ApplicationMailer
+  def new_follower(user, follower)
+    @user = user
+    @follower = follower
+    mail to: user.email, subject: '【お知らせ】フォローされました'
+  end
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -17,4 +17,12 @@
 class Relationship < ApplicationRecord
   belongs_to :follower, class_name: 'User'
   belongs_to :following, class_name: 'User'
+
+  after_create :send_email
+
+  private
+
+  def send_email
+    RelationshipMailer.new_follower(following, follower).deliver_now
+  end
 end

--- a/app/views/relationship_mailer/new_follower.html.haml
+++ b/app/views/relationship_mailer/new_follower.html.haml
@@ -1,0 +1,4 @@
+%p #{@user.email} さん
+%p 以下のユーザーにフォローされました。
+
+= link_to 'プロフィールの確認する', account_url(@follower)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,6 +39,8 @@ Rails.application.configure do
 
   # Set localhost to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  config.action_mailer.delivery_method = :letter_opener_web
+  config.action_mailer.perform_deliveries = true
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
   devise_for :users
   root to: 'articles#index'
   resource :timeline, only: [:show]


### PR DESCRIPTION
## 概要
- メール送付機能の実装

## 対応内容
- メール送信用のメイラーを作成し、ユーザーフォロー時にメールが送信されるように実装
- 開発環境でメール内容をブラウザで確認できるように `letter_opener` を導入
- `letter_opener` の設定を `development.rb` に追加

## 動作確認方法
### メール送信
1. サーバーを起動し（例：`bin/dev`）、作成済みユーザーでログインする。
2. 任意のユーザーをフォローする。
3. メールが送信され、ブラウザで `http://localhost:3000/letter_opener` にアクセスして内容を確認できる

## 画面のスクリーンショット
| ユーザーフォロー後のメール（letter_opener） |
| --- |
| <img width="1131" height="543" alt="image" src="https://github.com/user-attachments/assets/9998fc42-f130-423d-a9a8-0c6e3a75391e" />|

## 備考
- 本番環境では `letter_opener` は無効
- 開発環境専用の設定であり、`Gemfile` の `development` グループに追加済み
